### PR TITLE
Add functionality to allow moving files to a new file

### DIFF
--- a/dmenufm
+++ b/dmenufm
@@ -139,10 +139,10 @@ Generate_action_menu () {
 			cd "$actCHOICE" || exit 1
 			dmenufm_history
 			continue
-		elif [ -f "$actCHOICE" ]; then
+		elif [ -f "$actCHOICE" ] || [ -n "$allownew" ]; then
 			HERE=$(printf '%s' "$PWD/$actCHOICE")
 			name=$(printf '%s' "$HERE" | awk -F '/' '{print $NF}')
-		 	break
+			break
 		else
 			HERE=
 			name=
@@ -215,10 +215,11 @@ dmenufm_action (){
 			;;
 		"$FM_MV")
 			Generate_action_menu "Source: " "#33691e" || return
-			[ -n "$HERE" ] && start="$HERE" && startname="$name"
-			[ -n "$start" ] && Generate_action_menu "Destination: " "#FF8C00" || return
+			[ -n "$HERE" ] && start="$HERE" && startname="$name" && allownew="true"
+			[ -n "$start" ] && Generate_action_menu "Destination: " "#FF8C00" || return && allownew=
 			[ -n "$HERE" ] && destination="$HERE" && destname="$name"
 			[ -n "$HERE" ] && mv "$start" "$destination" && notifyprompt "$startname moved to $destname"
+			allownew=
 			;;
 		"$FM_RM")
 			# Choose file/directory in current directory to remove


### PR DESCRIPTION
With this change, during a move command you may type in the name of a new filename as the destination and this will move the file to the new file specified. There is a new variable `allownew` that will allow selective choice of when typing a new file name is acceptable. This means that for future additions this variable can easily be used for more than just the MVV action.
There is already the ability to create a new file and then move the old file onto it, however this takes two commands and can be cumbersome.

NOTE: The change on line 145 aligns the tab character, as before there was an extra space before the tab.