### PR TITLE
Remove uneeded mentions of dmenufm in help and fix bug with cd on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ Terminal=false
 
 You can replace `sxiv` to any GUI application which has the same issue.
 
+## Dmenu font is too big/small
+
+Open `dmenufm` script, and you can change the following three variables:
+
+```sh
+GENEFONT="Monospace-20"
+NOTIFONT="Monospace-30"
+DANGERFONT="Monospace-30"
+```
+
+- `GENEFONT` for general dmenu font size,
+- `NOTIFONT` for notification prompt, and
+- `DANGERFONT` for dangerous prompt for further confirmation in `RMM` and `TRH`.
+
+
 # TODO
 
 - Compress directory and extract files to different format.

--- a/dmenufm
+++ b/dmenufm
@@ -388,9 +388,13 @@ while [ -n "$1" ]; do
 			-f | --file: menu is files, no input
 			-D | --dotdirectory: menu is hidden directories, no input
 			-F | --dotfile: menu is hidden files, no input
+			-p | --lastpath: output the last path accessed (for cd on exit)
 			-h | --help: Show this message\\n"
 			exit 0
 			;;
+        "-p"|"--lastpath" )
+            outputpath="y"
+            ;;
 		"*" )
 			printf "Invalid option"
 			exit 1
@@ -401,3 +405,7 @@ done
 
 ### RUN THE MAIN FUNCTION
 dmenufm_menu
+
+if [ ! -z "$outputpath" ]; then
+    echo "$PWD"
+fi

--- a/dmenufm
+++ b/dmenufm
@@ -394,17 +394,14 @@ while [ -n "$1" ]; do
 			;;
 		"-h"|"--help" )
 			printf " Optional arguments for custom usage:
-			-d | --directory: dmenufm only show directories
-			-f | --file: dmenufm only show files
-			-D | --dotdirectory: dmenufm only show hidden directories
-			-F | --dotfile: dmenufm only hidden files
-			-p | --lastpath: dmenufm open on last working directory (cd on exit)
+			-d | --directory: dmenufm show only directories
+			-f | --file: dmenufm show only files
+			-D | --dotdirectory: dmenufm show only hidden directories
+			-F | --dotfile: dmenufm show only hidden files
+			-p | --lastpath: dmenufm opens on last working directory (cd on exit)
 			-h | --help: Show this message\\n"
 			exit 0
 			;;
-        "-p"|"--lastpath" )
-            outputpath="y"
-            ;;
 		"*" )
 			printf "Invalid option"
 			exit 1
@@ -418,6 +415,7 @@ done
 # --lastpath option:
 [ -n "$outputpath" ] && cd "$(cat "$LASTPATHFILE")"
 
+
 dmenufm_menu
 
-[ -n "$outputpath" ] && printf '%s' "$PWD" > "$LASTPATHFILE"
+printf '%s' "$PWD" > "$LASTPATHFILE"

--- a/dmenufm
+++ b/dmenufm
@@ -394,11 +394,11 @@ while [ -n "$1" ]; do
 			;;
 		"-h"|"--help" )
 			printf " Optional arguments for custom usage:
-			-d | --directory: dmenufm show only directories
-			-f | --file: dmenufm show only files
-			-D | --dotdirectory: dmenufm show only hidden directories
-			-F | --dotfile: dmenufm show only hidden files
-			-p | --lastpath: dmenufm opens on last working directory (cd on exit)
+			-d | --directory: only directories
+			-f | --file: only show files
+			-D | --dotdirectory: only show hidden directories
+			-F | --dotfile: only show hidden files
+			-p | --lastpath: opens in last working directory (cd on exit)
 			-h | --help: Show this message\\n"
 			exit 0
 			;;
@@ -414,7 +414,6 @@ done
 
 # --lastpath option:
 [ -n "$outputpath" ] && cd "$(cat "$LASTPATHFILE")"
-
 
 dmenufm_menu
 


### PR DESCRIPTION
What was happening with cd on exit was that if you ran it without the -p option then the next time you ran it with the -p option it wouldn't open in that directory.

For example if I open ~/downloads without the -p option the next time I open with the -p option I would expect it to be in the ~/downloads folder but instead it's in whichever directory I opened it from.