### PR TITLE
Add CPP command to copy files and update documentation accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Name with slash will consider as a directory; without as file.
 	- After choosing source, in the destination, type your new name (No need to add slash even for directory), and press `Shift+Return` to confirm inputed new name.
 	- Note: `Shift+Return` will confirm the input rather than patched menu item.
 
+### `CPP` to copy files to new / existing file
+
+- The usage of this action is the same as `MVR`, but will copy the file instead of moving it.
+
 ### `RMM` to remove
 
 Remove one directory or file.

--- a/dmenufm
+++ b/dmenufm
@@ -34,11 +34,12 @@ FM_CP_PATH="PCP - Copy path"
 FM_NEW="NEW - Create new file / directory"
 FM_RM="RMM - Remove files / directory"
 FM_MVR="MVR - Move files"
+FM_CP="CPP - Copy files"
 FM_TRASH="TRH - Trash of dmenufm"
 FM_HIST="HIS - History of dmenufm"
 FM_BMARK="BMK - Bookmark for dmenufm"
 FM_COMMAND="CMD - Frequently used command"
-ACTLIST="$FM_CP_PATH:$FM_NEW:$FM_MVR:$FM_RM:$FM_TRASH:$FM_HIST:$FM_BMARK:$FM_COMMAND"
+ACTLIST="$FM_CP_PATH:$FM_NEW:$FM_MVR:$FM_CP:$FM_RM:$FM_TRASH:$FM_HIST:$FM_BMARK:$FM_COMMAND"
 
 
 
@@ -245,13 +246,15 @@ dmenufm_action (){
 				:>"$name" && notifyprompt "File $name created."
 			fi
 			;;
-		"$FM_MVR")
+		"$FM_MVR"|"$FM_CP")
+			cmd="mv" && cmdname="moved"
+			[ "$move" = "$FM_CP" ] && cmd="cp" && cmdname="copied"
 			Generate_action_menu "Source: " "#33691e" || return
 			[ -n "$HERE" ] && start="$HERE" && startname="$name" && rename="true"
 			[ -d "$start" ] && cd "../"
-			[ -n "$start" ] && Generate_action_menu "Destination / Type rename: " "#FF8C00" || return && rename=
+			[ -n "$start" ] && Generate_action_menu "Destination / Type new name: " "#FF8C00" || return && rename=
 			[ -n "$HERE" ] && destination="$HERE" && destname="$name"
-			[ -n "$HERE" ] && mv "$start" "$destination" && notifyprompt "$startname moved to $destname"
+			[ -n "$HERE" ] && $cmd "$start" "$destination" && notifyprompt "$startname $cmdname to $destname"
 			rename=
 			;;
 		"$FM_RM")


### PR DESCRIPTION
Hey!
This commit adds the `CPP` command to copy files. For the sake of saving a lot of lines, I have made CPP use much of the already existing `MVR` command's case statement. If I were to rewrite the command as a new case statement, it would be almost 100% identical to the MVR command one. So, the case statement will now check if you chose MVR or CPP and accordingly use `mv` or `cp` based on that decision (stored in the `$cmd`. (cp or mv) and `cmdname` (copied or moved) vaiables). In addition, I changed "type rename" to "type new name" in the prompt as I felt this makes more sense, especially using it for both MVR and CPP.
Thank you.