### PR TITLE
Add notification for extracting archives

### DIFF
--- a/dmenufm
+++ b/dmenufm
@@ -224,7 +224,7 @@ extraction () {
 	dirname="$(printf '%s' "$2" | awk -F '/' '{printf $NF}' | awk -F '.' '{print $1}')"
 	mkdir -p "$dirname" && cd "$dirname" || exit
 	$1 "$2"
-	dmenufm
+	notifyprompt "$CHOICE extracted to $dirname"
 }
 
 # Actions that for dmenufm


### PR DESCRIPTION
This will add a notification stating which archive was extracted, and where it went. Also removed the `dmenufm` line as this works perfectly fine and just puts you right back into dmenufm already.