### PR TITLE
Fix invalid argument and allow user defined path to start in

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Put `dmenufm` in your `$PATH`.
 
 # Usage
 
-1. Type `dmenufm` to launch, or assign `dmenufm` to your favorite hot key.
+1. Type `dmenufm` to launch, or assign `dmenufm` to your favorite hot key. You may supply a directory as an argument to start dmenufm in the specified directory.
 2. `../` to go back to parent directory.
 3. `./` to open your file manager in currend working directory (determined by `xdg-open`)
 4. Choices with `/` are directory; choices without `/` are files.

--- a/dmenufm
+++ b/dmenufm
@@ -507,9 +507,13 @@ while [ -n "$1" ]; do
 			-h | --help: Show this message\\n"
 			exit 0
 			;;
-		"*" )
-			printf "Invalid option"
-			exit 1
+		*)
+			if [ -d "$1" ]; then
+				cd "$1"
+			else
+				printf '%s\n' "Invalid option"
+				exit 1
+			fi
 			;;
 	esac
 	shift


### PR DESCRIPTION
This commit fixes invalid arguments, as before the * was in quotes, negating its meaning as everything else and instead only matching if the user typed "*" as a command line argument.
In addition it is now checked if the unknown argument is a directory, and if so will start dmenufm in that directory instead of the current one.