### PR TITLE
Fix errors and issues regarding Bulk Rename

### DIFF
--- a/dmenufm
+++ b/dmenufm
@@ -363,7 +363,8 @@ dmenufm_action () {
 				else
 					bulkrename=$(paste -d ':' "$DMENUFM_BULK_RENAMEFILE.backup" "$DMENUFM_BULK_RENAMEFILE")
 					oldIFS=$IFS
-					IFS=$'\n'
+					IFS="
+					"
 					for selection in $(printf '%s' "$bulkrename"); do
 						start=$(printf '%s' "$selection" | awk -F ':' '{print $1}')
 						destination=$(printf '%s' "$selection" | awk -F ':' '{print $2}')

--- a/dmenufm
+++ b/dmenufm
@@ -362,6 +362,8 @@ dmenufm_action () {
 					notifyprompt "ERROR: Lines mismatch in rename file; do nothing." && return
 				else
 					bulkrename=$(paste -d ':' "$DMENUFM_BULK_RENAMEFILE.backup" "$DMENUFM_BULK_RENAMEFILE")
+					oldIFS=$IFS
+					IFS=$'\n'
 					for selection in $(printf '%s' "$bulkrename"); do
 						start=$(printf '%s' "$selection" | awk -F ':' '{print $1}')
 						destination=$(printf '%s' "$selection" | awk -F ':' '{print $2}')
@@ -369,6 +371,7 @@ dmenufm_action () {
 						echo "DEBUG: destination is $destination"
 						mv "$start" "$destination"
 					done && notifyprompt "Selected renamed"
+					IFS="$oldIFS"
 				fi
 			elif [ "$actCHOICE" = "$allselection" ]; then
 				return

--- a/dmenufm
+++ b/dmenufm
@@ -369,7 +369,11 @@ dmenufm_action () {
 						destination=$(printf '%s' "$selection" | awk -F ':' '{print $2}')
 						echo "DEBUG: start is $start"
 						echo "DEBUG: destination is $destination"
-						mv "$start" "$destination"
+						if [ "$start" = "$destination" ]; then
+							continue
+						else
+							mv "$start" "$destination"
+						fi
 					done && notifyprompt "Selected renamed"
 					IFS="$oldIFS"
 				fi


### PR DESCRIPTION
Hey!
This pull request solves #12 
Using the built in shell variable `$IFS`, we can make sure that files with spaces in their name are properly handled by bulk rename.
In addition, if the filename is not changed in bulk rename then the file will not attempt to be moved.