### PR TITLE
Fix IFS messing with commands (FINALLY)

### DIFF
--- a/dmenufm
+++ b/dmenufm
@@ -366,10 +366,10 @@ destmenu () {
 		IFS="
 		"
 		for selection in $(printf '%s' "$SELECTED"); do
+			IFS="$oldIFS"
 			$cmd "$selection" "$destination"
 		done && notifyprompt \
 			"Selected files / directories $cmdname to $destname"
-		IFS="$oldIFS"
 	fi
 
 }

--- a/dmenufm
+++ b/dmenufm
@@ -535,9 +535,9 @@ dmenufm_action () {
 					IFS="
 					"
 					for selection in $(printf '%s' "$SELECTED"); do
+						IFS="$oldIFS"
 						rm -rf "$selection"
 					done && notifyprompt "Selected removed."
-					IFS="$oldIFS"
 				fi
 			elif [ "$actCHOICE" = "$allselection" ]; then
 				SELECTED=$(printf '%s' "$list" \
@@ -606,9 +606,9 @@ dmenufm_action () {
 							IFS="
 							"
 							for selection in $(printf '%s' "$SELECTED"); do
+								IFS="$oldIFS"
 								mv "$selection" "$FM_TRASH"
 							done && notifyprompt "Selected files moved to trash"
-							IFS="$oldIFS"
 						fi
 					elif [ "$actCHOICE" = "$allselection" ]; then
 						SELECTED=$(printf '%s' "$list" \
@@ -622,9 +622,9 @@ dmenufm_action () {
 							IFS="
 							"
 							for selection in $(printf '%s' "$SELECTED"); do
+								IFS="$oldIFS"
 								mv "$selection" "$FM_TRASH"
 							done && notifyprompt "All files / directories moved to trash."
-							IFS="$oldIFS"
 						fi
 					else
 						# Single-selection mode


### PR DESCRIPTION
OKAY!
I believe this will solve both the space name #15 issue and the newly introduced unknown command `cp -R` issue by this commit #16 , do test to verify this but it seems to work for me when using dash.
Also worth mentioning this will negate #17 unless further issues arise with this.

The issue was caused by me not realizing using IFS as new line would try to parse `cp -R` as a whole command (and thus ln -s), the more you know I guess, had no clue this would be a side effect of setting the IFS in the wrong position!