### PR TITLE
Implementing the ability to compress files/directories

### DIFF
--- a/dmenufm
+++ b/dmenufm
@@ -339,13 +339,14 @@ bulk_compress () {
 	done
 	archive_name=$(echo "" \
 		| verticalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
-		| cut -d'.' -f1)
+		| cut -d'.' -f1) || return
 	compressdir_name="$archive_name"
 	archive_name="$archive_name.$compression_type"
 	mv "$FM_COMPRESSPATH" "./$compressdir_name"
 	$cmd $archive_name ./$compressdir_name
 	rm -rf ./$compressdir_name
 	## TODO: Add error handling
+	## TODO: Make sure you can escape out of all ZIP commands
 }
 
 # Bulk rename function.
@@ -563,6 +564,11 @@ dmenufm_action () {
 				| verticalprompt "Compression type: " "$FM_ACTION_COLOR_LV1" \
 				|| return \
 				&& allowmulti="NotAllowed")
+			if echo "$compression_type" | grep 'tar'; then
+				continue
+			else
+				allowmulti="NotAllowed"
+			fi
 			Generate_action_menu "Source: " "$FM_ACTION_COLOR_LV1" \
 				|| return \
 				&& allowmulti="NotAllowed"

--- a/dmenufm
+++ b/dmenufm
@@ -341,8 +341,7 @@ bulk_compress () {
 		unset IFS
 		cp -R "$file" "$FM_COMPRESSPATH"
 	done
-	archive_name=$(echo "" \
-		| verticalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
+	archive_name=$(horizontalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
 		| cut -d'.' -f1) || return
 	compressdir_name="$archive_name"
 	archive_name="$archive_name.$compression_type"

--- a/dmenufm
+++ b/dmenufm
@@ -337,10 +337,15 @@ bulk_compress () {
 		unset IFS
 		cp -R "$file" "$FM_COMPRESSPATH"
 	done
-	mv "$FM_COMPRESSPATH" "./placeholder"
-	archive_name="placeholder_archive.$compression_type"
-	$cmd $archive_name ./placeholder # TODO: Use variable name to make sure that user defined paths will work, not just this hardcoded one.
-	rm -rf ./placeholder
+	archive_name=$(echo "" \
+		| verticalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
+		| cut -d'.' -f1)
+	compressdir_name="$archive_name"
+	archive_name="$archive_name.$compression_type"
+	mv "$FM_COMPRESSPATH" "./$compressdir_name"
+	$cmd $archive_name ./$compressdir_name
+	rm -rf ./$compressdir_name
+	## TODO: Add error handling
 }
 
 # Bulk rename function.

--- a/dmenufm
+++ b/dmenufm
@@ -550,7 +550,7 @@ dmenufm_action () {
 				rename=
 			fi
 			;;
-		"$FM_CMP")
+		"$FM_ZIP")
 			allowmulti="Bulk Compress"
 			allselection="Bulk Compress all"
 			compression_type=$(printf '%s' "$COMPRESSIONLIST" \

--- a/dmenufm
+++ b/dmenufm
@@ -348,7 +348,9 @@ bulk_compress () {
 		archive_name="$archive_name.$compression_type"
 		mv "$FM_ZIPATH" "./$compressdir_name"
 		$cmd $archive_name ./$compressdir_name/* \
-			&& notifyprompt "Compressed to $archive_name" rm -rf ./$compressdir_name else
+			&& notifyprompt "Compressed to $archive_name" 
+		rm -rf ./$compressdir_name 
+	else
 		IFS="
 		"
 		for file in $SELECTED; do

--- a/dmenufm
+++ b/dmenufm
@@ -57,7 +57,7 @@ FM_BMK="BMK - Bookmark for dmenufm"
 FM_CMD="CMD - Frequently used command"
 FM_ZIP="ZIP - Compress files / directories"
 ACTLIST="$FM_PCP:$FM_NEW:$FM_MVR:$FM_YAK:$FM_LNK:$FM_DEL:$FM_TRH:$FM_REM:$FM_HIS:$FM_BMK:$FM_CMD:$FM_ZIP"
-COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:"
+COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:xz:lzma:gz:bz2"
 
 
 ### FUNCTIONS
@@ -332,22 +332,46 @@ bulk_compress () {
 		"tar.bz2")
 			cmd="tar -cjvf"
 			;;
+		"gz")
+			cmd="gzip -k"
+			;;
+		"bz2")
+			cmd="bzip2 -k"
+			;;
+		"xz")
+			cmd="xz -k"
+			;;
+		"lzma")
+			cmd="lzma -k"
+			;;
+		*)
+			return
+			;;
 	esac
-	[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
-	mkdir "$FM_ZIPATH"
-	IFS="
-	"
-	for file in $SELECTED; do
-		unset IFS
-		cp -R "$file" "$FM_ZIPATH"
-	done
-	archive_name=$(horizontalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
-		| cut -d'.' -f1) || return
-	compressdir_name="$archive_name"
-	archive_name="$archive_name.$compression_type"
-	mv "$FM_ZIPATH" "./$compressdir_name"
-	$cmd $archive_name ./$compressdir_name
-	rm -rf ./$compressdir_name
+	if echo "$compression_type" | grep 'tar'; then
+		[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
+		mkdir "$FM_ZIPATH"
+		IFS="
+		"
+		for file in $SELECTED; do
+			unset IFS
+			cp -R "$file" "$FM_ZIPATH"
+		done
+		archive_name=$(horizontalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
+			| cut -d'.' -f1) || return
+		compressdir_name="$archive_name"
+		archive_name="$archive_name.$compression_type"
+		mv "$FM_ZIPATH" "./$compressdir_name"
+		$cmd $archive_name ./$compressdir_name
+		rm -rf ./$compressdir_name
+	else
+		IFS="
+		"
+		for file in $SELECTED; do
+			unset IFS
+			$cmd "$file"
+		done
+	fi
 	## TODO: Add error handling
 	## TODO: Make sure you can escape out of all ZIP commands
 }

--- a/dmenufm
+++ b/dmenufm
@@ -333,7 +333,7 @@ bulk_compress () {
 		"zip") cmd="zip -r" ;;
 		*) return ;;
 	esac
-	if echo "$compression_type" | grep -E '^tar|^zip|^7z'; then
+	if echo "$compression_type" | grep -E '^tar|^zip'; then
 		[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
 		mkdir "$FM_ZIPATH"
 		IFS="
@@ -348,8 +348,8 @@ bulk_compress () {
 		archive_name="$archive_name.$compression_type"
 		mv "$FM_ZIPATH" "./$compressdir_name"
 		$cmd $archive_name ./$compressdir_name/* \
-			&& notifyprompt "Compressed to $archive_name" 
-		rm -rf ./$compressdir_name 
+			&& notifyprompt "Compressed to $archive_name"
+		rm -rf ./$compressdir_name
 	else
 		IFS="
 		"
@@ -586,7 +586,7 @@ dmenufm_action () {
 				| verticalprompt "Compression type: " "$FM_ACTION_COLOR_LV1" \
 				|| return \
 				&& allowmulti="NotAllowed")
-			if echo "$compression_type" | grep -E '^tar|^zip|^7z'; then
+			if echo "$compression_type" | grep -E '^tar|^zip'; then
 				continue
 			else
 				allowmulti="NotAllowed"

--- a/dmenufm
+++ b/dmenufm
@@ -57,7 +57,7 @@ FM_BMK="BMK - Bookmark for dmenufm"
 FM_CMD="CMD - Frequently used command"
 FM_ZIP="ZIP - Compress files / directories"
 ACTLIST="$FM_PCP:$FM_NEW:$FM_MVR:$FM_YAK:$FM_LNK:$FM_DEL:$FM_TRH:$FM_REM:$FM_HIS:$FM_BMK:$FM_CMD:$FM_ZIP"
-COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:xz:lzma:gz:bz2"
+COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:xz:lzma:gz:bz2:7z"
 
 
 ### FUNCTIONS
@@ -344,11 +344,14 @@ bulk_compress () {
 		"lzma")
 			cmd="lzma -k"
 			;;
+		"7z")
+			cmd="7z a"
+			;;
 		*)
 			return
 			;;
 	esac
-	if echo "$compression_type" | grep -E '^tar|^zip'; then
+	if echo "$compression_type" | grep -E '^tar|^zip|^7z'; then
 		[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
 		mkdir "$FM_ZIPATH"
 		IFS="
@@ -597,7 +600,7 @@ dmenufm_action () {
 				| verticalprompt "Compression type: " "$FM_ACTION_COLOR_LV1" \
 				|| return \
 				&& allowmulti="NotAllowed")
-			if echo "$compression_type" | grep 'tar'; then
+			if echo "$compression_type" | grep -E '^tar|^zip|^7z'; then
 				continue
 			else
 				allowmulti="NotAllowed"

--- a/dmenufm
+++ b/dmenufm
@@ -105,7 +105,7 @@ open () {
 		*.Z) extraction "uncompress" "$1" ;;
 		*.7z) extraction "7z x" "$1" ;;
 		*.xz) extraction "unxz" "$1" ;;
-		*.exe) extraction "cabextract" "$1" ;;
+		*.cab) extraction "cabextract" "$1" ;;
 		*)
 			case "$mimetype" in
 				text/*|*x-empty*|*json*)

--- a/dmenufm
+++ b/dmenufm
@@ -333,19 +333,19 @@ bulk_compress () {
 			cmd="tar -cjvf"
 			;;
 	esac
-	[ -d "$FM_COMPRESSPATH" ] && rm -rf "$FM_COMPRESSPATH"
-	mkdir "$FM_COMPRESSPATH"
+	[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
+	mkdir "$FM_ZIPATH"
 	IFS="
 	"
 	for file in $SELECTED; do
 		unset IFS
-		cp -R "$file" "$FM_COMPRESSPATH"
+		cp -R "$file" "$FM_ZIPATH"
 	done
 	archive_name=$(horizontalprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" \
 		| cut -d'.' -f1) || return
 	compressdir_name="$archive_name"
 	archive_name="$archive_name.$compression_type"
-	mv "$FM_COMPRESSPATH" "./$compressdir_name"
+	mv "$FM_ZIPATH" "./$compressdir_name"
 	$cmd $archive_name ./$compressdir_name
 	rm -rf ./$compressdir_name
 	## TODO: Add error handling

--- a/dmenufm
+++ b/dmenufm
@@ -16,6 +16,7 @@
 [ -n "$FM_CMDFILE" ] || FM_CMDFILE="$FM_PATH/dmenufm_command"
 [ -n "$FM_HISFILE" ] || FM_HISFILE="$FM_PATH/dmenufm_history"
 [ -n "$FM_LASTPATH" ] || FM_LASTPATH="$FM_PATH/dmenufm_lastpath"
+[ -n "$FM_COMPRESSPATH" ] || FM_COMPRESSPATH="$FM_PATH/compression/"
 [ -n "$FM_REMFILE" ] || FM_REMFILE="$FM_PATH/dmenufm_bulk_rename"
 # Max number for history
 [ -n "$FM_MAX_HIS_LENGTH" ] || FM_MAX_HIS_LENGTH=5000
@@ -321,16 +322,18 @@ bulk_compress () {
 			cmd="tar -cjvf"
 			;;
 	esac
+	[ -d "$FM_COMPRESSPATH" ] && rm -rf "$FM_COMPRESSPATH"
+	mkdir "$FM_COMPRESSPATH"
 	IFS="
 	"
 	for file in $SELECTED; do
 		unset IFS
-		compress_files="$compress_files $file"
+		cp -R "$file" "$FM_COMPRESSPATH"
 	done
-	compress_files=$(printf '%s' "$compress_files" \
-	| cut -b2-)
-	archive_name="placeholder_name.$compression_type"
-	$cmd $archive_name $compress_files
+	cd "$FM_COMPRESSPATH" && cd ../
+	archive_name="placeholder_archive.$compression_type"
+	$cmd $archive_name compression # TODO: Use variable name to make sure that user defined paths will work, not just this hardcoded one.
+	rm -rf $FM_COMPRESSPATH
 }
 
 # Bulk rename function.

--- a/dmenufm
+++ b/dmenufm
@@ -330,10 +330,10 @@ bulk_compress () {
 		unset IFS
 		cp -R "$file" "$FM_COMPRESSPATH"
 	done
-	cd "$FM_COMPRESSPATH" && cd ../
+	mv "$FM_COMPRESSPATH" "./placeholder"
 	archive_name="placeholder_archive.$compression_type"
-	$cmd $archive_name compression # TODO: Use variable name to make sure that user defined paths will work, not just this hardcoded one.
-	rm -rf $FM_COMPRESSPATH
+	$cmd $archive_name ./placeholder # TODO: Use variable name to make sure that user defined paths will work, not just this hardcoded one.
+	rm -rf ./placeholder
 }
 
 # Bulk rename function.

--- a/dmenufm
+++ b/dmenufm
@@ -57,8 +57,7 @@ FM_BMK="BMK - Bookmark for dmenufm"
 FM_CMD="CMD - Frequently used command"
 FM_ZIP="ZIP - Compress files / directories"
 ACTLIST="$FM_PCP:$FM_NEW:$FM_MVR:$FM_YAK:$FM_LNK:$FM_DEL:$FM_TRH:$FM_REM:$FM_HIS:$FM_BMK:$FM_CMD:$FM_ZIP"
-COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:xz:lzma:gz:bz2:7z"
-
+COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:xz:lzma:gz:bz2:7z:zip"
 
 ### FUNCTIONS
 
@@ -323,33 +322,16 @@ dmenufm_history () {
 
 bulk_compress () {
 	case $compression_type in
-		"tar.gz")
-			cmd="tar -czvf"
-			;;
-		"tar.xz")
-			cmd="tar -cJvf"
-			;;
-		"tar.bz2")
-			cmd="tar -cjvf"
-			;;
-		"gz")
-			cmd="gzip -k"
-			;;
-		"bz2")
-			cmd="bzip2 -k"
-			;;
-		"xz")
-			cmd="xz -k"
-			;;
-		"lzma")
-			cmd="lzma -k"
-			;;
-		"7z")
-			cmd="7z a"
-			;;
-		*)
-			return
-			;;
+		"tar.gz") cmd="tar -czvf" ;;
+		"tar.xz") cmd="tar -cJvf" ;;
+		"tar.bz2") cmd="tar -cjvf" ;;
+		"gz") cmd="gzip -k" ;;
+		"bz2") cmd="bzip2 -k" ;;
+		"xz") cmd="xz -k" ;;
+		"lzma") cmd="lzma -k" ;;
+		"7z") cmd="7z a" ;;
+		"zip") cmd="zip -r" ;;
+		*) return ;;
 	esac
 	if echo "$compression_type" | grep -E '^tar|^zip|^7z'; then
 		[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
@@ -365,19 +347,21 @@ bulk_compress () {
 		compressdir_name="$archive_name"
 		archive_name="$archive_name.$compression_type"
 		mv "$FM_ZIPATH" "./$compressdir_name"
-		$cmd $archive_name ./$compressdir_name/*
-		rm -rf ./$compressdir_name
-	else
+		$cmd $archive_name ./$compressdir_name/* \
+			&& notifyprompt "Compressed to $archive_name" rm -rf ./$compressdir_name else
 		IFS="
 		"
 		for file in $SELECTED; do
 			unset IFS
-			$cmd "$file"
+			$cmd "$file" \
+				&& notifyprompt "Compressed to $archive_name"
 		done
 	fi
 	## TODO: Add error handling
 	## TODO: Make sure you can escape out of all ZIP commands
+		# Added, but need testing
 }
+
 
 # Bulk rename function.
 # No argument
@@ -605,18 +589,19 @@ dmenufm_action () {
 			else
 				allowmulti="NotAllowed"
 			fi
-			Generate_action_menu "Source: " "$FM_ACTION_COLOR_LV1" \
+			[ -n "$compression_type" ] \
+				&& Generate_action_menu "Source: " "$FM_ACTION_COLOR_LV1" \
 				|| return \
 				&& allowmulti="NotAllowed"
 			if [ -n "$multiselection" ]; then
 				dmenufm_multiselect "Select files / directories to compress: "
-				bulk_compress
+				[ "$actCHOICE" = "$ENDSELECTION" ] && bulk_compress
 			elif [ "$actCHOICE" = "$allselection" ]; then
 				bulk_all_list
 				bulk_compress
 			else
 				SELECTED="$HERE"
-				bulk_compress
+				[ -n "$SELECTED" ] && bulk_compress
 			fi
 			;;
 		"$FM_REM")
@@ -628,13 +613,14 @@ dmenufm_action () {
 				&& allowmulti="NotAllowed"
 			if [ -n "$multiselection" ]; then
 				dmenufm_multiselect "Select files / directories to rename: "
-				bulk_rename
+				[ -n "$SELECTED" ] && bulk_rename
 			elif [ "$actCHOICE" = "$allselection" ]; then
 				bulk_all_list
 				bulk_rename
 			else
+
 				SELECTED="$HERE"
-				bulk_rename
+				[ -n "$SELECTED" ] && bulk_rename
 			fi
 			;;
 		"$FM_DEL")

--- a/dmenufm
+++ b/dmenufm
@@ -348,7 +348,7 @@ bulk_compress () {
 			return
 			;;
 	esac
-	if echo "$compression_type" | grep 'tar'; then
+	if echo "$compression_type" | grep -E '^tar|^zip'; then
 		[ -d "$FM_ZIPATH" ] && rm -rf "$FM_ZIPATH"
 		mkdir "$FM_ZIPATH"
 		IFS="
@@ -362,7 +362,7 @@ bulk_compress () {
 		compressdir_name="$archive_name"
 		archive_name="$archive_name.$compression_type"
 		mv "$FM_ZIPATH" "./$compressdir_name"
-		$cmd $archive_name ./$compressdir_name
+		$cmd $archive_name ./$compressdir_name/*
 		rm -rf ./$compressdir_name
 	else
 		IFS="

--- a/dmenufm
+++ b/dmenufm
@@ -586,12 +586,7 @@ dmenufm_action () {
 				dmenufm_multiselect "Select files / directories to compress: "
 				bulk_compress
 			elif [ "$actCHOICE" = "$allselection" ]; then
-				SELECTED=$(printf '%s' "$list" \
-					| tr ':' '\n' \
-					| sed "s/'//g; /^$/ d; s=^=$PWD/=g")
-				[ -n "$SELECTED" ] \
-					&& printf '%s' "$SELECTED" \
-					| verticalprompt "Selected files (Enter to continue): " "$FM_ACTION_COLOR_LV1"
+				bulk_all_list
 				bulk_compress
 			else
 				SELECTED="$HERE"

--- a/dmenufm
+++ b/dmenufm
@@ -49,12 +49,14 @@ FM_DEL="DEL - Delete files / directories"
 FM_MVR="MVR - Move files / directories"
 FM_YAK="YAK - Copy files / directories"
 FM_LNK="LNK - Symbolically link files / directories"
+FM_CMP="CMP - Compress files / directories"
 FM_REM="REM - Rename files / directories"
 FM_TRH="TRH - Trash of dmenufm"
 FM_HIS="HIS - History of dmenufm"
 FM_BMK="BMK - Bookmark for dmenufm"
 FM_CMD="CMD - Frequently used command"
-ACTLIST="$FM_PCP:$FM_NEW:$FM_MVR:$FM_YAK:$FM_LNK:$FM_DEL:$FM_TRH:$FM_REM:$FM_HIS:$FM_BMK:$FM_CMD"
+ACTLIST="$FM_PCP:$FM_NEW:$FM_MVR:$FM_YAK:$FM_LNK:$FM_CMP:$FM_DEL:$FM_TRH:$FM_REM:$FM_HIS:$FM_BMK:$FM_CMD"
+COMPRESSIONLIST="tar.gz:tar.bz2:tar.xz:"
 
 
 ### FUNCTIONS
@@ -305,6 +307,32 @@ dmenufm_history () {
 	fi
 }
 
+# Bulk compression
+
+bulk_compress () {
+	case $compression_type in
+		"tar.gz")
+			cmd="tar -czvf"
+			;;
+		"tar.xz")
+			cmd="tar -cJvf"
+			;;
+		"tar.bz2")
+			cmd="tar -cjvf"
+			;;
+	esac
+	IFS="
+	"
+	for file in $SELECTED; do
+		unset IFS
+		compress_files="$compress_files $file"
+	done
+	compress_files=$(printf '%s' "$compress_files" \
+	| cut -b2-)
+	archive_name="placeholder_name.$compression_type"
+	$cmd $archive_name $compress_files
+}
+
 # Bulk rename function.
 # No argument
 
@@ -512,6 +540,33 @@ dmenufm_action () {
 				[ -n "$SELECTED" ] \
 					&& destmenu
 				rename=
+			fi
+			;;
+		"$FM_CMP")
+			allowmulti="Bulk Compress"
+			allselection="Bulk Compress all"
+			compression_type=$(printf '%s' "$COMPRESSIONLIST" \
+				| tr ':' '\n' \
+				| verticalprompt "Compression type: " "$FM_ACTION_COLOR_LV1" \
+				|| return \
+				&& allowmulti="NotAllowed")
+			Generate_action_menu "Source: " "$FM_ACTION_COLOR_LV1" \
+				|| return \
+				&& allowmulti="NotAllowed"
+			if [ -n "$multiselection" ]; then
+				dmenufm_multiselect "Select files / directories to compress: "
+				bulk_compress
+			elif [ "$actCHOICE" = "$allselection" ]; then
+				SELECTED=$(printf '%s' "$list" \
+					| tr ':' '\n' \
+					| sed "s/'//g; /^$/ d; s=^=$PWD/=g")
+				[ -n "$SELECTED" ] \
+					&& printf '%s' "$SELECTED" \
+					| verticalprompt "Selected files (Enter to continue): " "$FM_ACTION_COLOR_LV1"
+				bulk_compress
+			else
+				SELECTED="$HERE"
+				bulk_compress
 			fi
 			;;
 		"$FM_REM")


### PR DESCRIPTION
**NOTE: most recent comment has most recent update, much of this is comment is outdated**

Hey, getting this here so we can work on common ground. Here is the very simple way in which I believe we should set this up.
In its current state, we have some work to do with tar in specific. Here is a quick example of what happens if you try it right now with files (I compressed 3 files "a" "b" and "c" in the directory "/home/cameron/sandbox") with dmenufm and here is the result of me looking at the compressed file.
```
$ ls                                        
a  b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  placeholder_name.tar.gz  q  r  s  t  u  v  w  x  y  z
$ tar -xzf placeholder_name.tar.gz 
$ tree
.
├── a
├── b
├── c
├── d
├── e
├── f
├── g
├── h
├── home
│   └── cameron
│       └── sandbox
│           ├── a
│           ├── b
│           └── c
├── i
├── j
├── k
├── l
├── m
├── n
├── o
├── p
├── placeholder_name.tar.gz
├── q
├── r
├── s
├── t
├── u
├── v
├── w
├── x
├── y
└── z

3 directories, 30 files
```

As you can see, tar does not play nicely with using absolute file paths and makes nested folders leading to the path inside of the archive. To solve this, I feel we could use the existing copy action in order to copy the files to a temporary directory (`$FM_PATH/compression/`?) and then just compress that directory. That will make the whole process **alot** smoother on our end. If you have another idea or want to continue with this let me know.