### PR TITLE
Add configuration file support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,19 @@ For compression, now you can choose the compression, and it will extract into a 
 
 There are many environment variables you can use to configure dmenufm by exporting them in your system or shell configuration file.
 
+Alternatively write the configuration to `dmenufm_config` in `$HOME/.config/dmenufm` or what ever you have set `FM_PATH` to.
+
+Example:
+
+    FM_GENERIC_FONT="Iosevka:pixelsize=26:antialias=true:autohint=true"
+    FM_NOTIF_FONT="$FM_GENERIC_FONT"
+    FM_DANGER_FONT="$FM_GENERIC_FONt"
+    FM_SUDO_COLOR="#bf616a"
+    FM_GENERIC_COLOR="#2e3440"
+    FM_ACTION_COLOR_LVL1="#2e3440"
+    FM_ACTION_COLOR_LVL2="#4c566a"
+    FM_ACTION_COLOR_LVL3="#d8dee9"
+
 The default options are as follows:
 
 ```sh

--- a/dmenufm
+++ b/dmenufm
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# source configuration file
+if [ -r "${FM_PATH:-$HOME/.config/dmenufm}/dmenufm_config" ]; then
+    . "${FM_PATH:-$HOME/.config/dmenufm}/dmenufm_config"
+fi
+
 ### OPTIONS AND VARIABLES
 
 ## OPTIONS

--- a/dmenufm
+++ b/dmenufm
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 # source configuration file
-if [ -r "${FM_PATH:-$HOME/.config/dmenufm}/dmenufm_config" ]; then
-    . "${FM_PATH:-$HOME/.config/dmenufm}/dmenufm_config"
+if [ -r "${FM_PATH:-$HOME/.config/dmenufm}/dmenufmrc" ]; then
+    . "${FM_PATH:-$HOME/.config/dmenufm}/dmenufmrc"
+else
+    cp ./dmenufmrc "${FM_PATH:-$HOME/.config/dmenufm}/dmenufmrc"
 fi
 
 ### OPTIONS AND VARIABLES


### PR DESCRIPTION
Instead of having a dozen or more environment variables set to configure dmenufm, add support for writing the configuration to a simple configuration file, basically a shell script that is sourced on each invocation.

I personally find this way cleaner.