### PR TITLE
Make sure that only windows opened by dmenufm are closed with EYE

### DIFF
--- a/dmenufm-action
+++ b/dmenufm-action
@@ -553,7 +553,7 @@ FM_EYE () {
     preview="true"
 
     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	dmenu -f -fn "$FM_GENERIC_FONT" -b -i -h 40 -sb "$2" -p "$1"
+	dmenu -f -fn "$FM_GENERIC_FONT" -b -i -sb "$2" -p "$1"
     }
 
     ActionMenu "Preview mode: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
@@ -564,7 +564,7 @@ FM_EYE () {
 	eyeid="$(xprop -root _NET_ACTIVE_WINDOW | cut -d ' ' -f 5)"
 	[ -n "$HERE" ] && FileOpen "$HERE" &
     done
-    wmctrl -c :ACTIVE:
+    wmctrl -ic "$eyeid"
 
     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
 	dmenu -f -fn "$FM_GENERIC_FONT" -i -sb "$2" -l 10 -p "$1"


### PR DESCRIPTION
Fixes #31 

Hi, marking this as a draft because I am awaiting a response on if the `-h` flag is simply just missing in the dmenu of my repos, and this fork does not contain the `-h` flag.

I believe after testing this should solve the issue well. I have tested:
+ Using EYE, opening multiple files and then quitting out of EYE
+ Using EYE, but not opening any files then quitting EYE
+ Using EYE when dmenufm was opened from a terminal
+ Using EYE when dmenufm was opened from a terminal, but not opening any files then quitting EYE

All of the above have worked for me without killing any windows other than the ones opened by selecting them.

Let me know if this is a sufficient fix or if I made a mistake in my testing/understanding. Thanks.