### PR TITLE
[WIP] Allow separate programs to be used in place of fzf/dmenufm

### DIFF
--- a/fzffm
+++ b/fzffm
@@ -14,6 +14,10 @@ case $FM_PROG in
 		[ -z "$FM_OPTS" ] && FM_OPTS="-l 10"
 		FM_OPT_PROMPT="-p"
 		;;
+	"rofi")
+		[ -z "$FM_OPTS" ] && FM_OPTS="-dmenu -l 10"
+		FM_OPT_PROMPT="-p"
+		;;
 	"")
 		echo "No program selected, falling back to fzf."
 		[ -z "$FM_OPTS" ] && FM_OPTS="--reverse"

--- a/fzffm
+++ b/fzffm
@@ -164,7 +164,7 @@ if [ "$(id -u)" -eq 0 ]; then
 	[ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 ")" = "Yes" ]
     }
 
-    FM_GENERIC_COLOR="$FM_SUDO_COLOR"
+    FM_OPTS_GENERIC="-sb $FM_SUDO_COLOR"
 
     MainMenu
 else

--- a/fzffm
+++ b/fzffm
@@ -5,6 +5,27 @@ FM_PATH="$HOME/.config/fzffm"
 FM_CACHE_PATH="$HOME/.cache/fzffm"
 [ -r "$FM_PATH/fzffm.conf" ] && . "$FM_PATH/fzffm.conf" || [ -r "/etc/fzffm.conf" ] && . "/etc/fzffm.conf" || echo 'Run `sudo make install` first to install all fzffm files.'
 
+case $FM_PROG in
+	"fzf")
+		FM_OPT_PROMPT="--prompt"
+		FM_OPT_REVERSE="--reverse"
+		FM_OPT_NOSORT="--no-sort"
+		;;
+	"bemenu")
+		FM_OPT_PROMPT="-p"
+		;;
+	"")
+		echo "No program selected, falling back to fzf."
+		FM_PROG="fzf"
+		FM_OPT_PROMPT="--prompt"
+		FM_OPT_REVERSE="--reverse"
+		FM_OPT_NOSORT="--no-sort"
+		;;
+	*)
+		echo "Program \`$FM_PROG\` not recognized, trying to run with prompt option '--prompt'."
+		;;
+esac
+
 # SUDO setting
 export SUDO_ASKPASS="$FM_SDOPROP"
 
@@ -43,7 +64,7 @@ nl='
 [ ! -f "$FM_PATH/fzffm.conf" ] && cp "/etc/fzffm.conf" "$FM_PATH/fzffm.conf"
 [ ! -d "$FM_CACHE_PATH" ] && mkdir -p "$FM_CACHE_PATH"
 [ ! -d "$FM_TRASH" ] && mkdir -p "$FM_TRASH"
-printf '%s\n' '#!/bin/sh' 'fzf --reverse --prompt "$1 " <&- && echo' > "$FM_SDOPROP"
+printf '%s\n' '#!/bin/sh' "${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} \"$1 \" <&- && echo" > "$FM_SDOPROP"
 chmod +x "$FM_SDOPROP"
 
 . fzffm-open
@@ -120,15 +141,15 @@ done
 if [ "$(id -u)" -eq 0 ]; then
     # super user privilege
     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	fzf --reverse --prompt "SUDO: $1 "
+	${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
     xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-	printf '%s' "" | fzf --reverse --prompt "SUDO: $1 "
+	printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
     DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-	[ "$(printf "No\\nYes" | fzf --reverse --prompt "SUDO: $1 ")" = "Yes" ]
+	[ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 ")" = "Yes" ]
     }
 
     FM_GENERIC_COLOR="$FM_SUDO_COLOR"

--- a/fzffm
+++ b/fzffm
@@ -12,10 +12,18 @@ case $FM_PROG in
 		;;
 	"bemenu")
 		[ -z "$FM_OPTS" ] && FM_OPTS="-l 10"
+		[ -z "$FM_OPTS_GENERIC" ] && FM_OPTS_GENERIC="--sb='#005577'"
+		[ -z "$FM_OPTS_ACTION_LV1" ] && FM_OPTS_ACTION_LV1="--sb='#33691e'"
+		[ -z "$FM_OPTS_ACTION_LV2" ] && FM_OPTS_ACTION_LV2="--sb='#FF8C00'"
+		[ -z "$FM_OPTS_ACTION_BULK" ] && FM_OPTS_ACTION_BULK="--sb='#CB06CB'"
 		FM_OPT_PROMPT="-p"
 		;;
 	"rofi")
 		[ -z "$FM_OPTS" ] && FM_OPTS="-dmenu -l 10"
+		[ -z "$FM_OPTS_GENERIC" ] && FM_OPTS_GENERIC="-sb '#005577'"
+		[ -z "$FM_OPTS_ACTION_LV1" ] && FM_OPTS_ACTION_LV1="-sb '#33691e'"
+		[ -z "$FM_OPTS_ACTION_LV2" ] && FM_OPTS_ACTION_LV2="-sb '#FF8C00'"
+		[ -z "$FM_OPTS_ACTION_BULK" ] && FM_OPTS_ACTION_BULK="-sb '#CB06CB'"
 		FM_OPT_PROMPT="-p"
 		;;
 	"")

--- a/fzffm
+++ b/fzffm
@@ -7,36 +7,24 @@ FM_CACHE_PATH="$HOME/.cache/fzffm"
 
 case $FM_PROG in
 	"fzf")
+		[ -z "$FM_OPTS" ] && FM_OPTS="--reverse"
 		FM_OPT_PROMPT="--prompt"
-		FM_OPT_REVERSE="--reverse"
-		FM_OPT_NOSORT="--no-sort"
 		;;
 	"bemenu")
+		[ -z "$FM_OPTS" ] && FM_OPTS="-l 10"
 		FM_OPT_PROMPT="-p"
 		;;
 	"")
 		echo "No program selected, falling back to fzf."
+		[ -z "$FM_OPTS" ] && FM_OPTS="--reverse"
 		FM_PROG="fzf"
 		FM_OPT_PROMPT="--prompt"
-		FM_OPT_REVERSE="--reverse"
-		FM_OPT_NOSORT="--no-sort"
 		;;
 	*)
-		echo "Program \`$FM_PROG\` not recognized, trying to run with prompt option '--prompt'."
+		[ -z "$FM_OPTS" ] && FM_OPTS=""
+		[ -z "$FM_OPT_PROMPT" ] && FM_OPT_PROMPT="--prompt" && echo "Program \`$FM_PROG\` not recognized, trying to run with prompt option '--prompt'. If this does not work, please use the FM_OPT_PROMPT variable to set it!"
 		;;
 esac
-
-makePromptOpts () {
-	cmdOpts=
-	for opt in "$@"; do
-		case $opt in
-			"reverse") cmdOpts="$cmdOpts ${FM_OPT_REVERSE}";;
-			"nosort") cmdOpts="$cmdOpts ${FM_OPT_NOSORT}";;
-			"prompt") cmdOpts="$cmdOpts ${FM_OPT_PROMPT}";;
-		esac
-	done
-	printf "%s" "$cmdOpts"
-}
 
 # SUDO setting
 export SUDO_ASKPASS="$FM_SDOPROP"
@@ -76,7 +64,7 @@ nl='
 [ ! -f "$FM_PATH/fzffm.conf" ] && cp "/etc/fzffm.conf" "$FM_PATH/fzffm.conf"
 [ ! -d "$FM_CACHE_PATH" ] && mkdir -p "$FM_CACHE_PATH"
 [ ! -d "$FM_TRASH" ] && mkdir -p "$FM_TRASH"
-printf '%s\n' '#!/bin/sh' "${FM_PROG} $(makePromptOpts reverse prompt) \"$1 \" <&- && echo" > "$FM_SDOPROP"
+printf '%s\n' '#!/bin/sh' "${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} \"$1 \" <&- && echo" > "$FM_SDOPROP"
 chmod +x "$FM_SDOPROP"
 
 . fzffm-open
@@ -153,15 +141,15 @@ done
 if [ "$(id -u)" -eq 0 ]; then
     # super user privilege
     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	    ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 "
+	    ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
     xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-	printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 "
+	printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
     DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-	[ "$(printf "No\\nYes" | ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 ")" = "Yes" ]
+	[ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 ")" = "Yes" ]
     }
 
     FM_GENERIC_COLOR="$FM_SUDO_COLOR"

--- a/fzffm
+++ b/fzffm
@@ -152,12 +152,12 @@ done
 
 if [ "$(id -u)" -eq 0 ]; then
     # super user privilege
-    yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	    ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 "
+    yprompt () { # Usage yprompt [MSG] [OPTS]
+	    ${FM_PROG} ${FM_OPTS} "$2" ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
-    xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-	printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "SUDO: $1 "
+    xprompt () { # Usage xprompt [MSG] [OPTS]
+	printf '%s' "" | ${FM_PROG} ${FM_OPTS} "$2" ${FM_OPT_PROMPT} "SUDO: $1 "
     }
 
     DangerPrompt () { # Usage: DangerPrompt [MSG] && ...

--- a/fzffm
+++ b/fzffm
@@ -26,6 +26,18 @@ case $FM_PROG in
 		;;
 esac
 
+makePromptOpts () {
+	cmdOpts=
+	for opt in "$@"; do
+		case $opt in
+			"reverse") cmdOpts="$cmdOpts ${FM_OPT_REVERSE}";;
+			"nosort") cmdOpts="$cmdOpts ${FM_OPT_NOSORT}";;
+			"prompt") cmdOpts="$cmdOpts ${FM_OPT_PROMPT}";;
+		esac
+	done
+	printf "%s" "$cmdOpts"
+}
+
 # SUDO setting
 export SUDO_ASKPASS="$FM_SDOPROP"
 
@@ -64,7 +76,7 @@ nl='
 [ ! -f "$FM_PATH/fzffm.conf" ] && cp "/etc/fzffm.conf" "$FM_PATH/fzffm.conf"
 [ ! -d "$FM_CACHE_PATH" ] && mkdir -p "$FM_CACHE_PATH"
 [ ! -d "$FM_TRASH" ] && mkdir -p "$FM_TRASH"
-printf '%s\n' '#!/bin/sh' "${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} \"$1 \" <&- && echo" > "$FM_SDOPROP"
+printf '%s\n' '#!/bin/sh' "${FM_PROG} $(makePromptOpts reverse prompt) \"$1 \" <&- && echo" > "$FM_SDOPROP"
 chmod +x "$FM_SDOPROP"
 
 . fzffm-open
@@ -141,15 +153,15 @@ done
 if [ "$(id -u)" -eq 0 ]; then
     # super user privilege
     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 "
+	    ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 "
     }
 
     xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-	printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 "
+	printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 "
     }
 
     DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-	[ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_PROMPT} "SUDO: $1 ")" = "Yes" ]
+	[ "$(printf "No\\nYes" | ${FM_PROG} $(makePromptOpts reverse prompt) "SUDO: $1 ")" = "Yes" ]
     }
 
     FM_GENERIC_COLOR="$FM_SUDO_COLOR"

--- a/fzffm-action
+++ b/fzffm-action
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 FM_Action () { # Usage: FM_Action
-    move=$(printf '%s\n' "$ACTLIST" | yprompt "Actions:" "$FM_GENERIC_COLOR")
+    move=$(printf '%s\n' "$ACTLIST" | yprompt "Actions:" "$FM_OPTS_GENERIC")
     case $move in
 	"$FM_PCP") FM_PCP ;;
 	"$FM_NEW") FM_NEW ;;
@@ -21,7 +21,7 @@ FM_Action () { # Usage: FM_Action
 
 BulkListAll () { # Usage: BulkListAll
     SELECTED=$(printf '%s' "$list" | sed "/^$/ d; s=^=$PWD/=g")
-    [ -n "$SELECTED" ] && check=$(printf '%s' "$SELECTED" | yprompt "Check selections. (Enter to continue, ESC to quit)" "$FM_ACTION_COLOR_LV1")
+    [ -n "$SELECTED" ] && check=$(printf '%s' "$SELECTED" | yprompt "Check selections. (Enter to continue, ESC to quit)" "$FM_OPTS_ACTION_LV1")
 }
 
 
@@ -34,7 +34,7 @@ BulkListMass () { # Usage: BulkListMass
     FileOpen "$FM_MASFILE"
 
     SELECTED="$(cat -u $FM_MASFILE | sed "/^$/ d")"
-    [ -n "$SELECTED" ] && check=$(printf '%s' "$SELECTED" | yprompt "Check selections. (Enter to continue, ESC to quit)" "$FM_ACTION_COLOR_LV1")
+    [ -n "$SELECTED" ] && check=$(printf '%s' "$SELECTED" | yprompt "Check selections. (Enter to continue, ESC to quit)" "$FM_OPTS_ACTION_LV1")
 
     rm "$FM_MASFILE"
 }
@@ -42,10 +42,10 @@ BulkListMass () { # Usage: BulkListMass
 BulkMode () { # Usage: BulkMode [MSG]
     HERE=""
     bulklist=""
-    ActionMenu "$1" "$FM_ACTION_COLOR_BULK" || return && allowbulk="NotAllowed"
+    ActionMenu "$1" "$FM_OPTS_ACTION_BULK" || return && allowbulk="NotAllowed"
 
     while [ "$bulkselection" = "true" ]; do
-	ActionMenu "$1" "$FM_ACTION_COLOR_BULK" || return && allowbulk="NotAllowed"
+	ActionMenu "$1" "$FM_OPTS_ACTION_BULK" || return && allowbulk="NotAllowed"
 	HERE=$bulklist
 	allowbulk="NotAllowed"
     done
@@ -54,20 +54,20 @@ BulkMode () { # Usage: BulkMode [MSG]
     allowbulk="NotAllowed"
 
     if [ "$actCHOICE" = "$ENDSELECTION" ] && [ -n "$SELECTED" ]; then
-	check=$(printf '%s' "$SELECTED" | sed "/^$/ d" | yprompt "Check selections. (Enter to continue, ESC to quit) " "$FM_ACTION_COLOR_LV1")
+	check=$(printf '%s' "$SELECTED" | sed "/^$/ d" | yprompt "Check selections. (Enter to continue, ESC to quit) " "$FM_OPTS_ACTION_LV1")
     fi
 }
 
 
 FM_BMK () { # Usage: FM_BMK
-    markmenu=$(printf '%s\n' "$(cat -u "$FM_BMKFILE")" "Add BMK" "Delete BMK" | yprompt "Fzffm Bookmark" "$FM_GENERIC_COLOR")
+    markmenu=$(printf '%s\n' "$(cat -u "$FM_BMKFILE")" "Add BMK" "Delete BMK" | yprompt "Fzffm Bookmark" "$FM_OPTS_GENERIC")
     # Add \n at end of file
     if [ "$(tail -c 1 "$FM_BMKFILE")" != "" ]; then
 	echo >> "$FM_BMKFILE"
     fi
     case "$markmenu" in
 	"Add BMK")
-	    ActionMenu "Choose file / directory and add to BMK: " "$FM_ACTION_COLOR_LV1" || return
+	    ActionMenu "Choose file / directory and add to BMK: " "$FM_OPTS_ACTION_LV1" || return
 	    mark=${HERE##*/}
 	    if [ -n "$mark" ]; then
 		printf '%s' "$mark - $HERE" >> "$FM_BMKFILE" && NotiPrompt "$mark added."
@@ -114,15 +114,15 @@ ExecCMD () { # Usage: ExecCMD [CMD]
 }
 
 FM_CMD () { # Usage: FM_CMD
-    cmdmenu=$(printf '%s\n' "$(cat -u "$FM_CMDFILE")" "Add CMD" "Delete CMD" | yprompt "Fzffm Custom Command" "$FM_GENERIC_COLOR")
+    cmdmenu=$(printf '%s\n' "$(cat -u "$FM_CMDFILE")" "Add CMD" "Delete CMD" | yprompt "Fzffm Custom Command" "$FM_OPTS_GENERIC")
     # Add \n at end of file
     if [ "$(tail -c 1 "$FM_CMDFILE")" != "" ]; then
 	echo >> "$FM_CMDFILE"
     fi
     case "$cmdmenu" in
 	"Add CMD")
-	    addcmd=$(xprompt "Recording your command: " "$FM_ACTION_COLOR_LV1") || return
-	    desp=$(xprompt "Enter command description: " "$FM_ACTION_COLOR_LV1") || return
+	    addcmd=$(xprompt "Recording your command: " "$FM_OPTS_ACTION_LV1") || return
+	    desp=$(xprompt "Enter command description: " "$FM_OPTS_ACTION_LV1") || return
 	    if [ -n "$addcmd" ]; then
 		printf '%s' "$addcmd - $desp" >> "$FM_CMDFILE" && NotiPrompt "$addcmd added."
 	    fi
@@ -140,7 +140,7 @@ FM_CMD () { # Usage: FM_CMD
 		allowbulk="Bulk Execute"
 		allselection="Bulk Execute All"
 		masselection="Bulk Execute Mass"
-		ActionMenu "Choose and execute: " "$FM_ACTION_COLOR_LV1"
+		ActionMenu "Choose and execute: " "$FM_OPTS_ACTION_LV1"
 		if [ "$bulkselection" = "true" ]; then
 		    BulkMode "Select to execute: "
 		    [ -n "$check" ] && BulkCMD
@@ -179,7 +179,7 @@ FM_DEL () { # Usage: FM_DEL
     allowbulk="Bulk Delete"
     allselection="Bulk Delete All"
     masselection="Bulk Delete Mass"
-    ActionMenu "Remove file / directory: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+    ActionMenu "Remove file / directory: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
     if [ "$bulkselection" = "true" ]; then
 	BulkMode "Select files / directories to delete: "
 	[ -n "$check" ] && DangerMenu "rm -rf" "Delete all selected?" ""
@@ -226,13 +226,13 @@ History () { # Usage: History [DIR/FILE]
 
 FM_HIS () { # Usage: FM_HIS
     # Use sed command to mimic reverse of cat for POSIX.
-    goto=$(sed '1!G;h;$!d' "$FM_HISFILE" | yprompt "Fzffm History" "$FM_GENERIC_COLOR")
+    goto=$(sed '1!G;h;$!d' "$FM_HISFILE" | yprompt "Fzffm History" "$FM_OPTS_GENERIC")
     destination=${goto##* - }
     cd "$destination" || FileOpen "$destination"
 }
 
 DestMenu () { # Usage: DestMenu
-    ActionMenu "Destination: " "$FM_ACTION_COLOR_LV2" || return && allowbulk="NotAllowed" && actCHOICE="placeholder"
+    ActionMenu "Destination: " "$FM_OPTS_ACTION_LV2" || return && allowbulk="NotAllowed" && actCHOICE="placeholder"
     [ -n "$HERE" ] && destination="$HERE" && destname="$name"
     if [ -n "$HERE" ]; then
 	IFS="$nl"
@@ -270,7 +270,7 @@ FM_MYL () { # Usage: FM_MYL
 	    masselection="Bulk Link Mass"
 	    ;;
     esac
-    ActionMenu "Source: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+    ActionMenu "Source: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
     if [ "$bulkselection" = "true" ]; then
 	BulkMode "Select files / directories to $cmdverb: "
 	[ -n "$check" ] && DestMenu
@@ -289,7 +289,7 @@ FM_MYL () { # Usage: FM_MYL
 }
 
 NewFileDir () { # Usage: NewFileDir
-    name=$(xprompt "Type name for $newmenu; Press ESC to leave" "$FM_ACTION_COLOR_LV1") || return
+    name=$(xprompt "Type name for $newmenu; Press ESC to leave" "$FM_OPTS_ACTION_LV1") || return
     case "$name" in
 	'~') NotiPrompt "Alias to $HOME; not a proper name." && continue ;;
 	'/') NotiPrompt "Alias to root; not a proper name." && continue ;;
@@ -303,7 +303,7 @@ NewFileDir () { # Usage: NewFileDir
 
 FM_NEW () { # Usage: FM_NEW
     name="placeholder"
-    newmenu=$(printf '%s\n' "File" "Directory" | yprompt "Create new files or directories" "$FM_GENERIC_COLOR")
+    newmenu=$(printf '%s\n' "File" "Directory" | yprompt "Create new files or directories" "$FM_OPTS_GENERIC")
     while [ -n "$name" ]; do
 	if [ "$newmenu" = "File" ]; then
 	    cmd='touch'
@@ -317,7 +317,7 @@ FM_NEW () { # Usage: FM_NEW
 
 FM_PCP () { # Usage: FM_PCP
     # Copy path to xclip, and send notification.
-    ActionMenu "Copy file / directory path: " "$FM_ACTION_COLOR_LV1" || return
+    ActionMenu "Copy file / directory path: " "$FM_OPTS_ACTION_LV1" || return
     if [ -n "$HERE" ] && command -v xclip; then
 	printf '%s' "$HERE" | xclip -selection clipboard && NotiPrompt "Path $name copied to clipboard."
     elif [ -n "$HERE" ] && command -v xsel; then
@@ -376,7 +376,7 @@ FM_REM () { # Usage: FM_REM
     allowbulk="Bulk Rename"
     allselection="Bulk Rename All"
     masselection="Bulk Rename Mass"
-    ActionMenu "Source: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+    ActionMenu "Source: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
     if [ "$bulkselection" = "true" ]; then
 	BulkMode "Select files / directories to rename: "
 	[ -n "$check" ] && BulkRename
@@ -420,10 +420,10 @@ FM_TRH () { # Usage: FM_TRH
     allowbulk="Bulk Trash"
     allselection="Bulk Trash All"
     masselection="Bulk Trash Mass"
-    trashmenu=$(printf '%s\n' "Move to trash" "Go to trash" "Empty trash" | yprompt "Fzffm Trash" "$FM_GENERIC_COLOR")
+    trashmenu=$(printf '%s\n' "Move to trash" "Go to trash" "Empty trash" | yprompt "Fzffm Trash" "$FM_OPTS_GENERIC")
     case $trashmenu in
 	"Move to trash")
-	    ActionMenu "Move file / directory to trash: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+	    ActionMenu "Move file / directory to trash: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
 	    if [ "$bulkselection" = "true" ]; then
 		BulkMode "Select files / directories to move to trash: "
 		[ -n "$check" ] && DangerMenu "mv" "Move all selected to trash?" "$FM_TRASH"
@@ -484,7 +484,7 @@ BulkCompress () { # Usage: BulkCompress
 	    unset IFS
 	    cp -R "$file" "$FM_ZIPATH"
 	done
-	archive_name=$(xprompt "Please insert archive name: " "$FM_ACTION_COLOR_LV2" | cut -d '.' -f1) || return
+	archive_name=$(xprompt "Please insert archive name: " "$FM_OPTS_ACTION_LV2" | cut -d '.' -f1) || return
 	if [ -n "$archive_name" ]; then
 	    compressdir_name="$archive_name"
 	    archive_name="$archive_name.$compression_type"
@@ -507,11 +507,11 @@ FM_ZIP () { # Usage: FM_ZIP
     allowbulk="Bulk Compress"
     allselection="Bulk Compress All"
     masselection="Bulk Compress Mass"
-    compression_type=$(printf '%s\n' "$COMPRESSIONLIST" | yprompt "Compression type: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed")
+    compression_type=$(printf '%s\n' "$COMPRESSIONLIST" | yprompt "Compression type: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed")
     if ! printf '%s' "$compression_type" | grep -E '^tar|^zip'; then
 	allowbulk="NotAllowed"
     fi
-    [ -n "$compression_type" ] && ActionMenu "Source: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+    [ -n "$compression_type" ] && ActionMenu "Source: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
     if [ "$bulkselection" = "true" ]; then
 	BulkMode "Select files / directories to compress: "
 	[ -n "$check" ] && BulkCompress
@@ -534,21 +534,21 @@ FM_SDO () {
 # FM_EYE () {
 #     preview="true"
 
-#     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
+#     yprompt () { # Usage yprompt [MSG] [OPTS]
 # 	dmenu -f -fn "$FM_GENERIC_FONT" -b -i -sb "$2" -p "$1"
 #     }
 
-#     ActionMenu "Preview mode: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+#     ActionMenu "Preview mode: " "$FM_OPTSACTION_LV1" || return && allowbulk="NotAllowed"
 #     [ -n "$HERE" ] && FileOpen "$HERE" &
 #     while [ -n "$HERE" ]; do
 # 	wmctrl -ic "$eyeid" &
-# 	ActionMenu "Preview mode: " "$FM_ACTION_COLOR_LV1" || return && allowbulk="NotAllowed"
+# 	ActionMenu "Preview mode: " "$FM_OPTS_ACTION_LV1" || return && allowbulk="NotAllowed"
 # 	eyeid="$(xprop -root _NET_ACTIVE_WINDOW | cut -d ' ' -f 5)"
 # 	[ -n "$HERE" ] && FileOpen "$HERE" &
 #     done
 #     wmctrl -ic "$eyeid"
 
-#     yprompt () { # Usage yprompt [MSG] [BG_COLOR]
+#     yprompt () { # Usage yprompt [MSG] [OPTS]
 # 	dmenu -f -fn "$FM_GENERIC_FONT" -i -sb "$2" -l 10 -p "$1"
 #     }
 

--- a/fzffm-menu
+++ b/fzffm-menu
@@ -3,19 +3,19 @@
 
 ## PROMPT FUNCTIONS
 yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-    fzf --reverse --no-sort --prompt "$1 "
+    ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1 "
 }
 
 xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-    printf '%s' "" | fzf --reverse  --no-sort --prompt "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT}t "$1 "
 }
 
 NotiPrompt () { # Usage NotiPrompt [MSG]
-    printf '%s' "" | fzf --reverse --no-sort --prompt "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1 "
 }
 
 DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-    [ "$(printf "No\\nYes" | fzf --reverse --no-sort --prompt "$1")" = "Yes" ]
+    [ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1")" = "Yes" ]
 }
 
 

--- a/fzffm-menu
+++ b/fzffm-menu
@@ -3,19 +3,19 @@
 
 ## PROMPT FUNCTIONS
 yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-	${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
+	${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
 }
 
 xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-    printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
 }
 
 NotiPrompt () { # Usage NotiPrompt [MSG]
-    printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
 }
 
 DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-    [ "$(printf "No\\nYes" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1")" = "Yes" ]
+    [ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1")" = "Yes" ]
 }
 
 

--- a/fzffm-menu
+++ b/fzffm-menu
@@ -3,19 +3,19 @@
 
 ## PROMPT FUNCTIONS
 yprompt () { # Usage yprompt [MSG] [BG_COLOR]
-    ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1 "
+	${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
 }
 
 xprompt () { # Usage xprompt [MSG] [BG_COLOR]
-    printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT}t "$1 "
+    printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
 }
 
 NotiPrompt () { # Usage NotiPrompt [MSG]
-    printf '%s' "" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1 "
+    printf '%s' "" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1 "
 }
 
 DangerPrompt () { # Usage: DangerPrompt [MSG] && ...
-    [ "$(printf "No\\nYes" | ${FM_PROG} ${FM_OPT_REVERSE} ${FM_OPT_NOSORT} ${FM_OPT_PROMPT} "$1")" = "Yes" ]
+    [ "$(printf "No\\nYes" | ${FM_PROG} $(makePromptOpts reverse nosort prompt) "$1")" = "Yes" ]
 }
 
 

--- a/fzffm-menu
+++ b/fzffm-menu
@@ -3,15 +3,15 @@
 
 ## PROMPT FUNCTIONS
 yprompt () { # Usage yprompt [MSG] [OPTS]
-	${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
+	${FM_PROG} ${FM_OPTS} "$2" ${FM_OPT_PROMPT} "$1 "
 }
 
 xprompt () { # Usage xprompt [MSG] [OPTS]
-    printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPTS} "$2" ${FM_OPT_PROMPT} "$1 "
 }
 
 NotiPrompt () { # Usage NotiPrompt [MSG]
-    printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
+    printf '%s' "" | ${FM_PROG} ${FM_OPTS} "$2" ${FM_OPT_PROMPT} "$1 "
 }
 
 DangerPrompt () { # Usage: DangerPrompt [MSG] && ...

--- a/fzffm-menu
+++ b/fzffm-menu
@@ -2,11 +2,11 @@
 
 
 ## PROMPT FUNCTIONS
-yprompt () { # Usage yprompt [MSG] [BG_COLOR]
+yprompt () { # Usage yprompt [MSG] [OPTS]
 	${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
 }
 
-xprompt () { # Usage xprompt [MSG] [BG_COLOR]
+xprompt () { # Usage xprompt [MSG] [OPTS]
     printf '%s' "" | ${FM_PROG} ${FM_OPTS} ${FM_OPT_PROMPT} "$1 "
 }
 
@@ -80,7 +80,7 @@ UpdateMenu () { # Generate menu based on arguments
     done
 }
 
-ActionMenu () { # Usage: ActionMenu [MSG] [BG_COLOR]
+ActionMenu () { # Usage: ActionMenu [MSG] [OPTS]
     while [ -n "$actCHOICE" ]; do
 	if [ -n "$keeplist" ]; then
 	    UpdateMenu
@@ -192,7 +192,7 @@ MainMenu () { # Usage: MainMenu
 		rolldir=""
 	fi
 	TwoPWD
-	CHOICE=$(printf '%s\n' "$BACKWARD" "$TARGET" "$ACTION" "$TERM" "$list" | sed "/^$/ d" | yprompt "$TwoPWD" "$FM_GENERIC_COLOR")
+	CHOICE=$(printf '%s\n' "$BACKWARD" "$TARGET" "$ACTION" "$TERM" "$list" | sed "/^$/ d" | yprompt "$TwoPWD" "$FM_OPTS_GENERIC")
 	# Outcome matching
 	if [ "$CHOICE" = "$TARGET" ]; then
 	    if [ "$termpath" = "true" ]; then


### PR DESCRIPTION
Hello, making this a draft pull request to be worked on until it fits well and functionality is extended a bit.

With my changes, there is a new function, `makePromptOpts`. This functions job is to take input and parse them into the proper options for the respective program being used, and then passing them on to said program. In the main `fzffm` script there is now a case statement for new variable `$FM_PROG`. Based on what this variable is, it will set up other variables starting with `$FM_OPT_*` to align with that programs corresponding flags. For example, in fzf the flag to put the prompt at the top is `--reverse`. However, in the case of bemenu, there is no such option thus bemenu would complain about an invalid option. So, with `$FM_PROG="bemenu"`, this case statement sets this variable to be blank, and so when it is ultimately passed to bemenu there will be no adverse effects.

You will have a better understanding after you read through and test it yourself. Do let me know if you would like to take a different approach, though I do think this will work well when we add in more options and more programs to the mix.